### PR TITLE
Allow gulp-vulcanize to work with an inputstream

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function (options) {
 
 		var self = this;
 		var destFilename = path.join(options.dest, path.basename(file.path));
-		options.input = file.path;
+		options.input = path.join(path.dirname(file.path), '.' + path.basename(file.path));
 		options.output = destFilename;
 		vulcanize.setOptions(options, function () {});
 
@@ -36,7 +36,9 @@ module.exports = function (options) {
 				return;
 			}
 
+			fs.writeFileSync(options.input, file.contents);
 			vulcanize.processDocument();
+			fs.unlinkSync(options.input);
 
 			fs.readFile(destFilename, function (err, data) {
 				if (err) {


### PR DESCRIPTION
I gulp-prefix something (platform.js) to the file I want vulcanized. I know this is a hack until vulcanize supports setting your own streams upstream, but it helps in the meantime make gulp-vulcanize behave more like you expect.
