### PR TITLE
Change output path using relative path under basepath #12 and Change outputSrc to outputHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (options) {
 
 		options.input = file.path;
 		options.inputSrc = file.contents;
-		options.output = path.join(options.dest, path.basename(file.path));
+		options.output = path.join(options.dest, file.path.replace(file.base, ''));
 		options.outputHandler = function(filename, data, finished) {
 			this.push(new gutil.File({
 				cwd: file.cwd,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "vulcanize": "^0.7.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mkdirp": "^0.5.0",
+    "mocha": "*",
+    "rimraf": "^2.2.8"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,36 +2,91 @@
 var assert = require('assert');
 var fs = require('fs');
 var gutil = require('gulp-util');
+var mkdirp = require('mkdirp');
+var rimraf = require('rimraf');
+var path = require('path');
 var vulcanize = require('./');
 
-it('should vulcanize web components', function (cb) {
-	var i = 0;
-	var stream = vulcanize({
-		dest: 'tmp',
-		csp: true
+function copyTestFile (src, dest) {
+	fs.writeFileSync(dest, fs.readFileSync(src, 'utf8'), 'utf8');
+}
+
+describe('should vulcanize web components:', function (argument) {
+	var targets = ['', '/abc', '/xyz', '/xyz/abs'];
+
+	before(function(cb) {
+		rimraf('tmp', function (err) {
+    		if (err) {
+      			return cb(err);
+      		}
+
+    		mkdirp.sync('tmp');
+
+    		targets.forEach(function(t) {
+    			var dest = path.join('tmp/src' + t);
+    			mkdirp.sync(dest);
+    			copyTestFile('./fixture/index.html', path.join(dest, 'index.html'));
+    			copyTestFile('./fixture/import.html', path.join(dest, 'import.html'));
+    		});
+
+    		cb();
+  		});
+
 	});
 
-	stream.on('data', function (file) {
-		i++;
+	it('single', function (cb) {
+		var stream = vulcanize({
+			dest: 'tmp/build',
+			csp: true
+		});
 
-		if (/\.html$/.test(file.path)) {
+		stream.on('data', function (file) {
+			if (/\.html$/.test(file.path)) {
+				assert.equal(file.relative, 'index.html');
+				assert(/Imported/.test(file.contents.toString()));
+				return;
+			}
+
+			assert.equal(file.relative, 'index.js');
+			assert(/Polymer/.test(file.contents.toString()));
+		});
+
+		stream.on('end', cb);
+
+		stream.write(new gutil.File({
+			cwd: __dirname,
+			base: 'tmp/src',
+			path: 'tmp/src/index.html',
+			contents: fs.readFileSync('tmp/src/index.html')
+		}));
+
+		stream.end();
+	});
+
+	it('multiple', function (cb) {
+		var stream = vulcanize({
+			dest: 'tmp/build'
+		});
+
+		stream.on('data', function (file) {
+			var t = path.dirname(file.path).replace('tmp/build', '');
+			assert(targets.indexOf(t) !== -1);
 			assert.equal(file.relative, 'index.html');
 			assert(/Imported/.test(file.contents.toString()));
-			return;
-		}
+		});
 
-		assert.equal(file.relative, 'index.js');
-		assert(/Polymer/.test(file.contents.toString()));
+		stream.on('end', cb);
+
+		targets.forEach(function(t) {
+			var src = path.join('tmp/src', t);
+			stream.write(new gutil.File({
+				cwd: __dirname,
+				base: 'tmp/src',
+				path: src + '/index.html',
+				contents: fs.readFileSync(src + '/index.html')
+			}));
+		});
+
+		stream.end();
 	});
-
-	stream.on('end', cb);
-
-	stream.write(new gutil.File({
-		cwd: __dirname,
-		base: __dirname + '/fixture',
-		path: __dirname + '/fixture/index.html',
-		contents: fs.readFileSync('fixture/index.html')
-	}));
-
-	stream.end();
 });


### PR DESCRIPTION
I've changed code handling output path. It will keep path under File.base that passed from stream by `gulp.src('src/**/*.html')` and I changed name of api of vulcanize `outputSrc`
