### PR TITLE
Update vulcanize version to 0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "through2": "^0.6.1",
-    "vulcanize": "^0.7.1"
+    "vulcanize": "^0.7.5"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Vulcanizing a large web application with `gulp-vulcanize` resulted in the following error:

    Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': Nodes of type 'HTML' may not be inserted inside nodes of type '#document'.

When I used the `vulcanize` binary on version 0.7.1, I got the same error, but updating the binary to 0.7.5 fixed the issue.