### PR TITLE
Bump to Vulcanize 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "through2": "^0.6.1",
-    "vulcanize": "^0.7.1"
+    "vulcanize": "^1.2.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
This change bumps you to the latest version of Vulcanize. It works quite well with [Polymer 0.8](https://www.polymer-project.org/0.8/) (which forms the new base for our 1.0), but breaks support for Polymer 0.5.

Totally up to you if you'd prefer to stick with supporting 0.5, but we've otherwise switched to supporting 0.8 moving forward.