### PR TITLE
Fix bug using absolute imports

### DIFF
--- a/fixture/index-absolute.html
+++ b/fixture/index-absolute.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<link rel="import" href="/import.html">
+	</head>
+	<body>
+		<x-import>Hello Import!</x-import>
+		<y-import></y-import>
+	</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var Vulcanize = require('vulcanize');
@@ -17,9 +18,12 @@ module.exports = function (opts) {
 			return;
 		}
 
-		(new Vulcanize(opts)).process(file.path, function (err, inlinedHtml) {
+		// vulcanize expects target path to be relative to abspath
+		let filePath = opts.abspath ? path.relative(opts.abspath, file.path) : file.path;
+
+		(new Vulcanize(opts)).process(filePath, function (err, inlinedHtml) {
 			if (err) {
-				cb(new gutil.PluginError('gulp-vulcanize', err, {fileName: file.path}));
+				cb(new gutil.PluginError('gulp-vulcanize', err, {fileName: filePath}));
 				return;
 			}
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,7 @@ describe('should vulcanize web components:', function () {
 			var dest = path.join('tmp', 'src', el);
 			mkdirp.sync(dest);
 			copyTestFile('fixture/index.html', path.join(dest, 'index.html'));
+			copyTestFile('fixture/index-absolute.html', path.join(dest, 'index-absolute.html'));
 			copyTestFile('fixture/import.html', path.join(dest, 'import.html'));
 		});
 	});
@@ -51,6 +52,32 @@ describe('should vulcanize web components:', function () {
 			cwd: __dirname,
 			base: path.join(__dirname, 'tmp', 'src'),
 			path: path.join('tmp', 'src', 'index.html'),
+			contents: fs.readFileSync(path.join('tmp', 'src', 'index.html'))
+		}));
+
+		stream.end();
+	});
+
+	it('absolute import', function (cb) {
+		var stream = vulcanize({abspath: path.join(__dirname, 'tmp', 'src')});
+
+		stream.on('data', function (file) {
+			if (/\.html$/.test(file.path)) {
+				assert.equal(file.relative, 'index-absolute.html');
+				assert(/Imported/.test(file.contents.toString()));
+				return;
+			}
+
+			assert.equal(file.relative, 'index.js');
+			assert(/Polymer/.test(file.contents.toString()));
+		});
+
+		stream.on('end', cb);
+
+		stream.write(new gutil.File({
+			cwd: __dirname,
+			base: path.join(__dirname, 'tmp', 'src'),
+			path: path.join('tmp', 'src', 'index-absolute.html'),
 			contents: fs.readFileSync(path.join('tmp', 'src', 'index.html'))
 		}));
 


### PR DESCRIPTION
Handle abspath, adjusting the file path given to vulcanize according to
the abspath option.

Also added a test for this situation.